### PR TITLE
Add tests for shaded spring-security-crypto dependencies

### DIFF
--- a/VulnShadingDemoApplication/.gitignore
+++ b/VulnShadingDemoApplication/.gitignore
@@ -1,0 +1,41 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store
+
+target/
+.idea/

--- a/VulnShadingDemoApplication/pom.xml
+++ b/VulnShadingDemoApplication/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.vuln_shading_demo</groupId>
+    <artifactId>VulnShadingDemoApplication</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>19</maven.compiler.source>
+        <maven.compiler.target>19</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+            <version>3.2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
+        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>com.example</groupId>-->
+<!--            <artifactId>spring-security-crypto-fail</artifactId>-->
+<!--            <version>0.0.1-SNAPSHOT</version>-->
+<!--        </dependency>-->
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>spring-security-crypto-success</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/VulnShadingDemoApplication/src/main/java/com/example/vuln_shading_demo/VulnShadingDemoApplication.java
+++ b/VulnShadingDemoApplication/src/main/java/com/example/vuln_shading_demo/VulnShadingDemoApplication.java
@@ -1,0 +1,4 @@
+package com.example.vuln_shading_demo;
+
+public class VulnShadingDemoApplication {
+}

--- a/VulnShadingDemoApplication/src/test/java/com/example/vuln_shading_demo/VulnShadingDemoApplicationTest.java
+++ b/VulnShadingDemoApplication/src/test/java/com/example/vuln_shading_demo/VulnShadingDemoApplicationTest.java
@@ -1,0 +1,68 @@
+package com.example.vuln_shading_demo;
+
+import com.example.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VulnShadingDemoApplicationTest {
+    private static final String AlphaNumericString = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            + "0123456789"
+            + "abcdefghijklmnopqrstuvwxyz";
+
+    private String generateRandomString(int n) {
+        StringBuilder sb = new StringBuilder(n);
+
+        for (int i = 0; i < n; i ++) {
+            int index = (int) (AlphaNumericString.length() * Math.random());
+            sb.append(AlphaNumericString.charAt(index));
+        }
+
+        return sb.toString();
+    }
+
+    @Test
+    public void testPwdMatch()
+    {
+        BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
+        String root1 = generateRandomString(72);
+        String root2 = generateRandomString(72);
+
+        String encodeRoot1 = bCryptPasswordEncoder.encode(root1);
+        System.out.println("encodeRoot1" + encodeRoot1);
+
+        String encodeRoot2 = bCryptPasswordEncoder.encode(root2);
+        System.out.println("encodeRoot2" + encodeRoot2);
+
+        assertTrue(bCryptPasswordEncoder.matches(root1, encodeRoot1));
+        assertTrue(bCryptPasswordEncoder.matches(root2, encodeRoot2));
+    }
+
+    @Test
+    public void testPwdMismatch()
+    {
+        BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
+        String root1 = generateRandomString(72);
+        String root2 = generateRandomString(72);
+
+        String encodeRoot1 = bCryptPasswordEncoder.encode(root1);
+        System.out.println("encodeRoot1" + encodeRoot1);
+
+        String encodeRoot2 = bCryptPasswordEncoder.encode(root2);
+        System.out.println("encodeRoot2" + encodeRoot2);
+
+        assertFalse(bCryptPasswordEncoder.matches(root1, encodeRoot2));
+    }
+
+    @Test
+    public void testLengthCheck()
+    {
+        BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
+        String rootPassword = generateRandomString(72);
+        String pwd1 = rootPassword + generateRandomString(5);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            bCryptPasswordEncoder.encode(pwd1);
+        });
+    }
+}


### PR DESCRIPTION
Add tests for shaded spring-security-crypto dependencies which can be used to show that it fails against the vulnerable version, and passes against the non-vulnerable version